### PR TITLE
Correction to aws_account var for live environment

### DIFF
--- a/groups/chips-control-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-control-db/profiles/heritage-live-eu-west-2/vars
@@ -1,7 +1,7 @@
 # Account details
 aws_profile = "heritage-live-eu-west-2"
 aws_region  = "eu-west-2"
-aws_account = "live-development"
+aws_account = "heritage-live"
 
 # Account shorthand
 account     = "hlive"


### PR DESCRIPTION
There was a typo in groups/chips-control-db/profiles/heritage-live-eu-west-2/vars which has been corrected.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1484