### PR TITLE
Add IAM policies to allow CHIPS ALB rule modification

### DIFF
--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -73,6 +73,28 @@ module "instance_profile" {
       actions = [
         "cloudwatch:PutMetricData"
       ]
+    },
+    {
+      sid       = "AllowDescribeALBs",
+      effect    = "Allow",
+      resources = ["*"],
+      actions = [
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeRules"
+      ]
+    },
+    {
+      sid       = "AllowCHIPSALBCreateAndDeleteRule",
+      effect    = "Allow",
+      resources = [
+        "arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:listener/app/alb-chips*",
+        "arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:listener-rule/app/alb-chips*"
+      ],
+      actions = [
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Updates the IAM Profile of the chips-control EC2 instances to:
- Allow describe of any ALBs/Listeners/Rules
- Allow create/delete of just listener rules on ALBs that have a name starting with `alb-chips`

Resolves:
https://companieshouse.atlassian.net/browse/CM-1498