### PR TITLE
Allow publishing to CHIPS SNS topics

### DIFF
--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -95,6 +95,16 @@ module "instance_profile" {
         "elasticloadbalancing:CreateRule",
         "elasticloadbalancing:DeleteRule"
       ]
+    },
+    {
+      sid       = "AllowCHIPSSNSPublish",
+      effect    = "Allow",
+      resources = [
+        "arn:aws:sns:${var.aws_region}:${data.aws_caller_identity.current.account_id}:chips*"
+      ],
+      actions = [
+        "sns:Publish"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Update the IAM profile to allow the chips-control EC2 instance to publish messages to any of the chips SNS topics.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1527