### PR TITLE
Add permissions for KMS operations to allow SNS message send

### DIFF
--- a/groups/chips-control-app/data.tf
+++ b/groups/chips-control-app/data.tf
@@ -24,6 +24,10 @@ data "aws_acm_certificate" "acm_cert" {
   most_recent = true
 }
 
+data "aws_kms_key" "sns_key" {
+  key_id = "alias/${var.account}/${var.region}/sns"
+}
+
 data "vault_generic_secret" "account_ids" {
   path = "aws-accounts/account-ids"
 }

--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -105,6 +105,17 @@ module "instance_profile" {
       actions = [
         "sns:Publish"
       ]
+    },
+    {
+      sid       = "AllowKMSOperationsForSNS",
+      effect    = "Allow",
+      resources = [
+        data.aws_kms_key.sns_key.arn
+      ],
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add further permissions to allow sending of SNS messages.  `kms:Decrypt` and `kms:GenerateDataKey*` are being added for the specific KMS key used for SNS.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1527