### PR TITLE
Allow access from Concourse workers to the chips-control ALB

### DIFF
--- a/groups/chips-control-app/alb.tf
+++ b/groups/chips-control-app/alb.tf
@@ -6,7 +6,10 @@ module "internal_alb_security_group" {
   description = "Security group for the ${var.application} servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.admin_cidrs
+  ingress_prefix_list_ids  = [
+    data.aws_ec2_managed_prefix_list.administration.id,
+    data.aws_ec2_managed_prefix_list.shared-services-management.id
+  ]
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }

--- a/groups/chips-control-app/asg.tf
+++ b/groups/chips-control-app/asg.tf
@@ -9,20 +9,20 @@ module "asg_security_group" {
   description = "Security group for the ${var.application} asg"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.admin_cidrs
+  ingress_prefix_list_ids  = [data.aws_ec2_managed_prefix_list.administration.id]
   ingress_rules       = ["ssh-tcp"]
 
-  ingress_with_source_security_group_id = [
-    {
-      from_port                = var.application_port
-      to_port                  = var.application_port
-      protocol                 = "tcp"
-      description              = "${var.application} port"
-      source_security_group_id = module.internal_alb_security_group.security_group_id
-    }
-  ]
-
   egress_rules = ["all-all"]
+}
+
+resource "aws_security_group_rule" "http_from_alb" {
+  description              = "HTTP from ALB"
+  from_port                = var.application_port
+  to_port                  = var.application_port
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = module.internal_alb_security_group.security_group_id
+  security_group_id        = module.asg_security_group.security_group_id
 }
 
 # ASG Module

--- a/groups/chips-control-app/data.tf
+++ b/groups/chips-control-app/data.tf
@@ -22,6 +22,10 @@ data "aws_ec2_managed_prefix_list" "shared-services-management" {
   name = "shared-services-management-cidrs"
 }
 
+data "vault_generic_secret" "ch_development_concourse_cidrs" {
+  path = "/aws-accounts/network/ch-development-private-management-cidrs"
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/chips-control-app/data.tf
+++ b/groups/chips-control-app/data.tf
@@ -14,6 +14,14 @@ data "aws_subnet_ids" "application" {
   }
 }
 
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
+}
+
+data "aws_ec2_managed_prefix_list" "shared-services-management" {
+  name = "shared-services-management-cidrs"
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true
@@ -30,10 +38,6 @@ data "aws_kms_key" "sns_key" {
 
 data "vault_generic_secret" "account_ids" {
   path = "aws-accounts/account-ids"
-}
-
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
 }
 
 data "vault_generic_secret" "ec2_data" {

--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -1,6 +1,4 @@
 locals {
-
-  admin_cidrs              = values(data.vault_generic_secret.internal_cidrs.data)
   ec2_data                 = data.vault_generic_secret.ec2_data.data
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])

--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  ec2_data                 = data.vault_generic_secret.ec2_data.data
+  ch_development_concourse_cidrs = values(data.vault_generic_secret.ch_development_concourse_cidrs.data)
+  ec2_data                       = data.vault_generic_secret.ec2_data.data
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 

--- a/groups/chips-control-app/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-control-app/profiles/heritage-development-eu-west-2/vars
@@ -19,6 +19,9 @@ enable_instance_refresh = true
 # Custom config bucket for development
 config_bucket_name = "heritage-development.eu-west-2.configs.ch.gov.uk"
 
+# Allow access from Concourse workers
+allow_concourse_access = true
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-control-app/variables.tf
+++ b/groups/chips-control-app/variables.tf
@@ -164,3 +164,9 @@ variable "domain_name" {
   default     = "*.companieshouse.gov.uk"
   description = "Domain Name for ACM Certificate"
 }
+
+variable "allow_concourse_access" {
+  type        = bool
+  default     = false
+  description = "Whether to allow concourse worker subnets access to the ALB"
+}


### PR DESCRIPTION
Use a prefix list instead of the internal_cidrs vault entry, and add a new entry for the shared-services management prefix list, as that will contain the subnets used by the new Concourse workers in shared services.

As we still need to allow access from the "old" Concourse workers in ch-development, for which there isn't currently a convenient prefix list, I have added ingress to port 443 on the ALB via the use of cidrs stored in vault.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1549

