### PR TITLE
Increase Live RDS instance size to db.t3.medium

### DIFF
--- a/groups/chips-control-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-control-db/profiles/heritage-live-eu-west-2/vars
@@ -11,7 +11,7 @@ environment = "live"
 # RDS settings
 rds_databases = {
   rundeck = {
-    instance_class             = "db.t3.small"
+    instance_class             = "db.t3.medium"
     allocated_storage          = 10
     backup_retention_period    = 2
     multi_az                   = true


### PR DESCRIPTION
We are having issues with memory on Live - this will upgrade the instance size to db.t3.medium, from db.t3.small, doubling the memory from 2GB to 4GB.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1553