### PR TITLE
Allow update of files in dev config bucket by Rundeck

### DIFF
--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -29,6 +29,7 @@ module "instance_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+        "s3:PutObject"
       ]
     },
     {


### PR DESCRIPTION
Add PutObject action to the IAM policy for the config bucket for the chips-control instance.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1552