### PR TITLE
Use launch template, enforce IMDSv2 and use encryption for swap

### DIFF
--- a/groups/chips-control-app/asg.tf
+++ b/groups/chips-control-app/asg.tf
@@ -27,14 +27,14 @@ resource "aws_security_group_rule" "http_from_alb" {
 
 # ASG Module
 module "asg" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/terraform-aws-autoscaling?ref=tags/1.0.36"
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.242"
 
   count = var.asg_count
 
   name = format("%s%s", var.application, count.index)
 
-  # Launch configuration
-  lc_name       = format("%s%s-launchconfig", var.application, count.index)
+  # Launch template
+  lt_name       = format("%s%s-launchtemplate", var.application, count.index)
   image_id      = data.aws_ami.ami.id
   instance_type = var.instance_size
   security_groups = [
@@ -43,11 +43,18 @@ module "asg" {
   root_block_device = [
     {
       volume_size = var.instance_root_volume_size
-      volume_type = "gp2"
       encrypted   = true
-      iops        = 0
-    },
+    }
   ]
+
+  block_device_mappings = [
+    {
+      device_name = "/dev/xvdb"
+      encrypted   = true
+      volume_size = var.instance_swap_volume_size
+    }
+  ]
+  
   # Auto scaling group
   asg_name                       = format("%s%s-asg", var.application, count.index)
   vpc_zone_identifier            = data.aws_subnet_ids.application.ids
@@ -63,6 +70,7 @@ module "asg" {
   refresh_triggers               = ["launch_configuration"]
   key_name                       = aws_key_pair.keypair.key_name
   termination_policies           = ["OldestLaunchConfiguration"]
+  enforce_imdsv2                 = var.enforce_imdsv2
 
   target_group_arns = [
     module.internal_alb.target_group_arns[0]

--- a/groups/chips-control-app/templates/user_data.tpl
+++ b/groups/chips-control-app/templates/user_data.tpl
@@ -3,8 +3,8 @@
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 #Get application instance identifier from tags in AWS metadata service
-EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_INSTANCE_ID=$( ec2-metadata -i | awk '{print $2}' )
+AVAILABILITY_ZONE=$( ec2-metadata -z | awk '{print $2}' )
 EC2_REGION=$${AVAILABILITY_ZONE::-1}
 APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=$EC2_INSTANCE_ID" "Name=key,Values=app-instance-name"  --region $EC2_REGION | jq -r '.Tags[]//[]|select(.Key=="app-instance-name")|.Value' )
 

--- a/groups/chips-control-app/variables.tf
+++ b/groups/chips-control-app/variables.tf
@@ -107,6 +107,12 @@ variable "instance_root_volume_size" {
   description = "Size of root volume attached to instances"
 }
 
+variable "instance_swap_volume_size" {
+  type        = number
+  default     = 5
+  description = "Size of swap volume attached to instances"
+}
+
 variable "enable_instance_refresh" {
   type        = bool
   default     = false
@@ -141,6 +147,12 @@ variable "enable_sns_topic" {
   type        = bool
   description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
+}
+
+variable "enforce_imdsv2" {
+  description = "Whether to enforce use of IMDSv2 by setting http_tokens to required on the aws_launch_configuration"
+  type        = bool
+  default     = true
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Switch to ASG module that uses a launch template instead of a launch configuration
Enforce IMDSv2 and update user data script to work with that
Use encryption for swap ebs volume
Remove gp2 volume type setting for root volume, so that the type comes from the AMI (which is gp3 now)

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731