### PR TITLE
Add null provider declaration to workaround issue with TF

### DIFF
--- a/groups/chips-control-app/main.tf
+++ b/groups/chips-control-app/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/vault"
       version = ">= 2.0.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
   }
   backend "s3" {}
 }


### PR DESCRIPTION
When running via the pipeline, terraform init was not downloading the hashicorp/null provider, which was causing a failure to run plan.

The terraform code does not use that provider, but the previous state still references it.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731