### PR TITLE
Add managed CIS scanning policy to instance role

### DIFF
--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -120,3 +120,8 @@ module "instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.instance_profile.aws_iam_role.name
+}

--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -36,6 +36,8 @@ locals {
     ApplicationType = upper(var.application_type)
     Region          = var.aws_region
     Account         = var.aws_account
+    Repository      = "chips-devtest-terraform"
+    Service         = "CHIPS"
   }
 
   userdata_ansible_inputs = {


### PR DESCRIPTION
Add managed policy to allow CIS scanning by Inspector

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2793