### PR TITLE
Grant access to correct ssm key for parameter store

### DIFF
--- a/groups/chips-control-app/iam.tf
+++ b/groups/chips-control-app/iam.tf
@@ -8,7 +8,8 @@ module "instance_profile" {
 
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
 
   cw_log_group_arns = length(local.log_groups) > 0 ? [format(
@@ -60,11 +61,12 @@ module "instance_profile" {
       ]
     },
     {
-      sid       = "AllowReadOfParameterStore",
+      sid       = "AllowReadWriteOfParameterStore",
       effect    = "Allow",
       resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/chips/*"],
       actions = [
-        "ssm:GetParameter*"
+        "ssm:GetParameter*",
+        "ssm:PutParameter"
       ]
     },
     {

--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -9,6 +9,7 @@ locals {
   logs_kms_key_id        = local.kms_keys_data["logs"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
   sns_kms_key_id         = local.kms_keys_data["sns"]
+  account_ssm_key_arn    = local.kms_keys_data["ssm"]
 
   security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]


### PR DESCRIPTION
Grants access to the account level ssm key for parameter store in order to allow the storage of secrets/config there instead of S3. 

Resolves:
https://companieshouse.atlassian.net/browse/CHP-64