### PR TITLE
HTTPS access from chips app instances to chips-control on heritage-dev

### DIFF
--- a/groups/chips-control-app/alb.tf
+++ b/groups/chips-control-app/alb.tf
@@ -15,7 +15,7 @@ module "internal_alb_security_group" {
   egress_rules        = ["all-all"]
 }
 
-resource "aws_security_group_rule" "ch-development-concourse" {
+resource "aws_security_group_rule" "ch_development_concourse" {
   count             = var.allow_concourse_access ? 1 : 0
   description       = "HTTPS from Concourse workers on ch-development"
   from_port         = 443
@@ -24,6 +24,18 @@ resource "aws_security_group_rule" "ch-development-concourse" {
   type              = "ingress"
   cidr_blocks       = local.ch_development_concourse_cidrs
   security_group_id = module.internal_alb_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "heritage_development_https" {
+  for_each = tomap(local.https_access_source_groups)
+
+  description              = "Access to HTTPS from ${each.key}"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = each.value
+  security_group_id        = module.internal_alb_security_group.security_group_id
 }
 
 module "internal_alb" {

--- a/groups/chips-control-app/data.tf
+++ b/groups/chips-control-app/data.tf
@@ -14,6 +14,19 @@ data "aws_subnet_ids" "application" {
   }
 }
 
+data "aws_security_groups" "https_access_group_ids" {
+  for_each = toset(var.https_access_sg_patterns)
+  filter {
+    name   = "group-name"
+    values = [each.key]
+  }
+}
+
+data "aws_security_group" "https_access_groups" {
+  for_each = toset(local.https_access_source_sg_ids)
+  id       = each.key
+}
+
 data "aws_ec2_managed_prefix_list" "administration" {
   name = "administration-cidr-ranges"
 }

--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -16,6 +16,9 @@ locals {
   elb_access_logs_bucket_name = local.security_s3_data["elb-access-logs-bucket-name"]
   elb_access_logs_prefix      = "elb-access-logs"
 
+  https_access_source_sg_ids = flatten([for sg in data.aws_security_groups.https_access_group_ids : sg.ids])
+  https_access_source_groups = {for group in data.aws_security_group.https_access_groups : group.tags.Name => group.id}
+
   nfs_mounts = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
 
   #For each log map passed, add an extra kv for the log group name and append the NFS directory into the filepath where required

--- a/groups/chips-control-app/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-control-app/profiles/heritage-development-eu-west-2/vars
@@ -22,6 +22,10 @@ config_bucket_name = "heritage-development.eu-west-2.configs.ch.gov.uk"
 # Allow access from Concourse workers
 allow_concourse_access = true
 
+https_access_sg_patterns = [
+  "sgr-chips-*-asg-001-*"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-control-app/variables.tf
+++ b/groups/chips-control-app/variables.tf
@@ -182,3 +182,9 @@ variable "allow_concourse_access" {
   default     = false
   description = "Whether to allow concourse worker subnets access to the ALB"
 }
+
+variable "https_access_sg_patterns" {
+  type        = list(string)
+  default     = []
+  description = "List of source security group name patterns that will have access to the ALB HTTPS port"
+}


### PR DESCRIPTION
Allow https access to the chips-control ALB to allow use of the Rundeck api from CHIPS EC2 instances on heritage-development

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-708