### PR TITLE
add admin prefix list and wire into sg rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # chips-control-terraform
 Infrastructure code to support CHIPS RunDeck service
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0, < 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 0.3, < 4.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 2.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 0.3, < 4.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | >= 2.0.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 2.23.0 |
+| <a name="module_rds_cloudwatch_alarms"></a> [rds\_cloudwatch\_alarms](#module\_rds\_cloudwatch\_alarms) | git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms | tags/1.0.181 |
+| <a name="module_rds_security_group"></a> [rds\_security\_group](#module\_rds\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_rds_start_stop_schedule"></a> [rds\_start\_stop\_schedule](#module\_rds\_start\_stop\_schedule) | git@github.com:companieshouse/terraform-modules//aws/rds_start_stop_schedule | tags/1.0.181 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_security_group_rule.admin_oracle_db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.admin_oracle_em](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_ec2_managed_prefix_list.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
+| [aws_iam_role.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [aws_route53_zone.private_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_security_group.rds_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_security_group.rds_shared](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnet_ids.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [vault_generic_secret.rundeck_rds](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account"></a> [account](#input\_account) | Short version of the name of the AWS Account in which resources will be administered | `string` | n/a | yes |
+| <a name="input_aws_account"></a> [aws\_account](#input\_aws\_account) | The name of the AWS Account in which resources will be administered | `string` | n/a | yes |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | The AWS profile to use | `string` | n/a | yes |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region in which resources will be administered | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment | `string` | n/a | yes |
+| <a name="input_parameter_group_settings"></a> [parameter\_group\_settings](#input\_parameter\_group\_settings) | A map whose keys represent RDS instances and whose values are a list of parameters that will be set in the RDS instance parameter group | `map(list(any))` | n/a | yes |
+| <a name="input_rds_cloudwatch_alarms"></a> [rds\_cloudwatch\_alarms](#input\_rds\_cloudwatch\_alarms) | A map whose keys represent RDS instances and whose values define RDS CloudWatch Alarms configuration | `map(map(any))` | n/a | yes |
+| <a name="input_rds_databases"></a> [rds\_databases](#input\_rds\_databases) | ------------------------------------------------------------------------------ RDS Variables ------------------------------------------------------------------------------ | `map` | n/a | yes |
+| <a name="input_rds_ingress_groups"></a> [rds\_ingress\_groups](#input\_rds\_ingress\_groups) | A map whose keys represent RDS instances and whose values are lists of strings representing security group filter patterns | `map(list(string))` | n/a | yes |
+| <a name="input_rds_start_stop_schedule"></a> [rds\_start\_stop\_schedule](#input\_rds\_start\_stop\_schedule) | A map whose keys represent RDS instances and whose values define configuration for RDS start/stop schedules | `map(map(any))` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Short version of the name of the AWS region in which resources will be administered | `string` | n/a | yes |
+| <a name="input_vault_password"></a> [vault\_password](#input\_vault\_password) | Password for connecting to Vault - usually supplied through TF\_VARS | `string` | n/a | yes |
+| <a name="input_vault_username"></a> [vault\_username](#input\_vault\_username) | Username for connecting to Vault - usually supplied through TF\_VARS | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/groups/chips-control-db/data.tf
+++ b/groups/chips-control-db/data.tf
@@ -44,6 +44,6 @@ data "vault_generic_secret" "rundeck_rds" {
   path = "applications/${var.aws_profile}/rundeck/rds"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
+data "aws_ec2_managed_prefix_list" "admin" {
+  name = "administration-cidr-ranges"
 }

--- a/groups/chips-control-db/locals.tf
+++ b/groups/chips-control-db/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  admin_cidrs    = values(data.vault_generic_secret.internal_cidrs.data)
-
   rds_data = {
     rundeck   = data.vault_generic_secret.rundeck_rds.data
   }

--- a/groups/chips-control-db/rds.tf
+++ b/groups/chips-control-db/rds.tf
@@ -11,22 +11,33 @@ module "rds_security_group" {
   description = format("Security group for the ${each.key} RDS database")
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.admin_cidrs
-  ingress_rules       = ["oracle-db-tcp"]
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 5500
-      to_port     = 5500
-      protocol    = "tcp"
-      description = "Oracle Enterprise Manager"
-      cidr_blocks = join(",", local.admin_cidrs)
-    }
-  ]
   ingress_with_source_security_group_id = local.rds_ingress_from_services[each.key]
 
   egress_rules = ["all-all"]
 }
+resource "aws_security_group_rule" "admin_oracle_db" {
+  for_each          = var.rds_databases
 
+  description       = "Allow Oracle DB listener from admin prefix list"
+  type              = "ingress"
+  from_port         = 1521
+  to_port           = 1521
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.admin.id]
+  security_group_id = module.rds_security_group[each.key].this_security_group_id
+}
+
+resource "aws_security_group_rule" "admin_oracle_em" {
+  for_each          = var.rds_databases
+
+  description       = "Allow Oracle Enterprise Manager from admin prefix list"
+  type              = "ingress"
+  from_port         = 5500
+  to_port           = 5500
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.admin.id]
+  security_group_id = module.rds_security_group[each.key].this_security_group_id
+}
 # ------------------------------------------------------------------------------
 # RDS Instance
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/DVOP-3599
Removed vault data lookup and replaced with admin prefix list data lookup
Removed admin_cidrs local
Restructured rds_security_group security group for use with the prefix list
Update README.md
`ingress_with_source_security_group_id` remains taken care of as its explicitly defined in locals

Plan: 2 to add, 0 to change, 2 to destroy.