### PR TITLE
feat: Add ServiceTeam: CSI tag and fix Respository tag in chipsControl

### DIFF
--- a/groups/chips-control-app/locals.tf
+++ b/groups/chips-control-app/locals.tf
@@ -40,8 +40,9 @@ locals {
     ApplicationType = upper(var.application_type)
     Region          = var.aws_region
     Account         = var.aws_account
-    Repository      = "chips-devtest-terraform"
+    Repository      = "chips-control-terraform"
     Service         = "CHIPS"
+    ServiceTeam     = "CSI"
   }
 
   userdata_ansible_inputs = {


### PR DESCRIPTION
Adds ServiceTeam:  csi tag chipsControl as part of CSI infrastructure tagging work.
- Tag addition only, no resource changes
- Linked Jira ticket: CSI-185